### PR TITLE
Generalize input source interface and add socket-based input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ LDBUS=`pkg-config --cflags dbus-1` -ldbus-1
 all: wmemulator packedtest wmmitm
 clean:
 	rm -f wmemulator packedtest wmmitm
-wmemulator: wmemulator.c wiimote.c input.c wm_crypto.c wm_reports.c wm_print.c sdp.c bdaddr.c adapter.c
-	gcc $(CFLAGS) -o wmemulator wmemulator.c wiimote.c input.c wm_crypto.c wm_reports.c wm_print.c sdp.c bdaddr.c adapter.c $(LBLUETOOTH) -lSDL -lpthread -lm $(LDBUS) -Wall
-wmmitm: wmmitm.c wiimote.c input.c wm_crypto.c wm_reports.c wm_print.c sdp.c bdaddr.c adapter.c
-	gcc $(CFLAGS) -o wmmitm wmmitm.c wiimote.c input.c wm_crypto.c wm_reports.c wm_print.c sdp.c bdaddr.c adapter.c $(LBLUETOOTH) -lSDL -lpthread -lm $(LDBUS) -Wall
+wmemulator: wmemulator.c wiimote.c input.c input_sdl.c input_socket.c wm_crypto.c wm_reports.c wm_print.c sdp.c bdaddr.c adapter.c
+	gcc $(CFLAGS) -o wmemulator wmemulator.c wiimote.c input.c input_sdl.c input_socket.c wm_crypto.c wm_reports.c wm_print.c sdp.c bdaddr.c adapter.c $(LBLUETOOTH) -lSDL -lpthread -lm $(LDBUS) -Wall
+wmmitm: wmmitm.c wiimote.c input.c input_sdl.c input_socket.c wm_crypto.c wm_reports.c wm_print.c sdp.c bdaddr.c adapter.c
+	gcc $(CFLAGS) -o wmmitm wmmitm.c wiimote.c input.c input_sdl.c input_socket.c wm_crypto.c wm_reports.c wm_print.c sdp.c bdaddr.c adapter.c $(LBLUETOOTH) -lSDL -lpthread -lm $(LDBUS) -Wall
 packedtest: packedtest.c
 	gcc -o packedtest packedtest.c

--- a/input.c
+++ b/input.c
@@ -32,6 +32,7 @@ int input_update(struct wiimote_state *state, struct input_source const * source
         show_reports = (show_reports + 1) % 2;
         break;
       }
+      break;
     case INPUT_EVENT_TYPE_HOTPLUG:
       switch (event.hotplug_event.extension)
       {
@@ -155,6 +156,7 @@ int input_update(struct wiimote_state *state, struct input_source const * source
         printf("warning: button %d not handled by input_update\n", event.button_event.button);
         break;
       }
+      break;
     }
     case INPUT_EVENT_TYPE_ANALOG_MOTION: {
       bool moving = event.analog_motion_event.moving;
@@ -224,6 +226,7 @@ int input_update(struct wiimote_state *state, struct input_source const * source
           motionplus_slow = moving;
           break;
       }
+      break;
     }
     default:
       break;

--- a/input.c
+++ b/input.c
@@ -3,448 +3,312 @@
 #include "SDL/SDL.h"
 #include <math.h>
 
-/* This old file badly needs refactoring. */
-
-int up, down, left, right;
-bool steerright, steerleft;
-double steerang = (PI / 2);
-int arrow_function = 0;
-bool togglekey0 = 0;
-bool togglekey9 = 0;
-bool shift;
+int ir_up, ir_down, ir_left, ir_right,
+    steer_left, steer_right,
+    nunchuk_up, nunchuk_down, nunchuk_left, nunchuk_right,
+    classic_left_stick_up, classic_left_stick_down, classic_left_stick_left, classic_left_stick_right,
+    motionplus_up, motionplus_down, motionplus_left, motionplus_right, motionplus_slow; 
+double steer_angle = (PI / 2);
 extern int show_reports;
 
-void input_init()
+int input_update(struct wiimote_state *state, struct input_source const * source)
 {
-  //init SDL
-  if (SDL_Init(0) < 0)
-  {
-    printf("Could not initialize SDL: %s\n", SDL_GetError());
-    exit(1);
-  }
-  SDL_SetVideoMode(128, 128, 0, 0);
-  printf("Commands overview\n"
-         "-----------------\n"
-         "                 __ arrows use keypad numbers!\n"
-         "     ........  L'\n"
-         "    |   .    |\\           ,.._\n"
-         "    |   8    | |        ,'    \\\\\n"
-         "    | -4 6-  | |        |   ^  |\\\n"
-         "    |   2    | |        | <-|->/ |q\n"
-         "    |   '    | |\\       `   v '  |\n"
-         "    |  /-\\   | |b|      |     | _/e\n"
-         "    |  |a|   |  \\|      |     //\n"
-         "    |  \\-/   |   |      |    |/\n"
-         "    |        |   |      |    |\n"
-         "    | 3 h 4  |   |       \\   /\n"
-         "    |        |   |        --'\n"
-         "    |        |   |        _...______________,...\n"
-         "    |   2    |   |      ,'                      `-\n"
-         "    |        |   |     /   ^      3 h 4       q   `.\n"
-         "    |   1    |  /      | <-|->             e    a  |\n"
-         "    |        |-/       \\   v                 b     /\n"
-         "    '`'''''''           \\                        ,'\n"
-         "     _     _             `-..-'------------`...-'\n"
-         "   ,'       `.\n"
-         "  ,' t     y '.     0: toggles arrow keys between\n"
-         "  V           V        IR/nunchuk/classic/motion plus\n"
-         "                    ESC: quit\n\n");
-}
-
-void input_unload()
-{
-  SDL_Quit();
-}
-
-int input_update(struct wiimote_state *state)
-{
-  SDL_Event event;
+  struct input_event event;
 
   /* Loop through waiting messages and process them */
 
-  while (SDL_PollEvent(&event))
+  while (source->poll_event(&event))
   {
     switch (event.type)
     {
-    case SDL_KEYDOWN:
-      switch (event.key.keysym.sym)
+    case INPUT_EVENT_TYPE_EMULATOR_CONTROL:
+      switch (event.emulator_control_event.control)
       {
-      case SDLK_ESCAPE:
-        if (shift)
-        {
-          //power off
-          return -2;
-        }
-        else
-        {
-          return -1;
-        }
-        break;
-
-      case SDLK_0:
-        if (togglekey0 == 0)
-        {
-          togglekey0 = 1;
-          arrow_function = (arrow_function + 1) % 4;
-          printf("arrows (IR, nunchuk, classic, wmp): %d \n", arrow_function);
-          if (arrow_function != 0)
-          {
-            ir_object_clear(state, 0);
-            ir_object_clear(state, 1);
-            ir_object_clear(state, 2);
-            ir_object_clear(state, 3);
-          }
-          else
-          {
-            state->usr.ir_object[0].x = 400;
-            state->usr.ir_object[0].y = 400;
-            state->usr.ir_object[0].size = 8;
-            state->usr.ir_object[1].x = 600;
-            state->usr.ir_object[1].y = 400;
-            state->usr.ir_object[1].size = 8;
-          }
-
-          if (arrow_function == 1)
-          {
-            state->usr.connected_extension_type = Nunchuk;
-          }
-          else if (arrow_function == 2)
-          {
-            state->usr.connected_extension_type = Classic;
-          }
-          else if (arrow_function == 3)
-          {
-            state->usr.connected_extension_type = Nunchuk;
-          }
-          else
-          {
-            state->usr.connected_extension_type = NoExtension;
-          }
-        }
-        break;
-      case SDLK_9:
-        if (togglekey9 == 0)
-        {
-          togglekey9 = 1;
-          show_reports = (show_reports + 1) % 2;
-        }
-        break;
-      case SDLK_LSHIFT:
-        shift = 1;
-        break;
-      case SDLK_a:
-        if (arrow_function == 2)
-        {
-          state->usr.classic.a = 1;
-        }
-        else
-        {
-          state->usr.a = 1;
-        }
-        break;
-      case SDLK_d:
-        if (arrow_function == 2)
-        {
-          state->usr.classic.b = 1;
-        }
-        else
-        {
-          state->usr.b = 1;
-        }
-        break;
-      case SDLK_q:
-        if (arrow_function == 2)
-        {
-          state->usr.classic.x = 1;
-        }
-        else
-        {
-          state->usr.nunchuk.c = 1;
-        }
-        break;
-      case SDLK_e:
-        if (arrow_function == 2)
-        {
-          state->usr.classic.y = 1;
-        }
-        else
-        {
-          state->usr.nunchuk.z = 1;
-        }
-        break;
-      case SDLK_1:
-        state->usr.one = 1;
-        break;
-      case SDLK_2:
-        state->usr.two = 1;
-        break;
-      case SDLK_3:
-        if (arrow_function == 2)
-        {
-          state->usr.classic.minus = 1;
-        }
-        else
-        {
-          state->usr.minus = 1;
-        }
-        break;
-      case SDLK_4:
-        if (arrow_function == 2)
-        {
-          state->usr.classic.plus = 1;
-        }
-        else
-        {
-          state->usr.plus = 1;
-        }
-        break;
-      case SDLK_h:
-        state->usr.home = 1;
-        break;
-      case SDLK_KP8:
-        if (arrow_function == 2)
-        {
-          state->usr.classic.up = 1;
-        }
-        else
-        {
-          state->usr.up = 1;
-        }
-        break;
-      case SDLK_KP2:
-        if (arrow_function == 2)
-        {
-          state->usr.classic.down = 1;
-        }
-        else
-        {
-          state->usr.down = 1;
-        }
-        break;
-      case SDLK_KP4:
-        if (arrow_function == 2)
-        {
-          state->usr.classic.left = 1;
-        }
-        else
-        {
-          state->usr.left = 1;
-        }
-        break;
-      case SDLK_KP6:
-        if (arrow_function == 2)
-        {
-          state->usr.classic.right = 1;
-        }
-        else
-        {
-          state->usr.right = 1;
-        }
-        break;
-      case SDLK_UP:
-        up = 1;
-        break;
-
-      case SDLK_DOWN:
-        down = 1;
-        break;
-
-      case SDLK_LEFT:
-        left = 1;
-        break;
-
-      case SDLK_RIGHT:
-        right = 1;
-        break;
-
-      case SDLK_t:
-        steerleft = 1;
-        break;
-      case SDLK_y:
-        steerright = 1;
-        break;
-      default:
+      case INPUT_EMULATOR_CONTROL_QUIT:
+        return -1;
+      case INPUT_EMULATOR_CONTROL_POWER_OFF:
+        return -2;
+      case INPUT_EMULATOR_CONTROL_TOGGLE_REPORTS:
+        show_reports = (show_reports + 1) % 2;
         break;
       }
-      break;
-
-    case SDL_KEYUP:
-      switch (event.key.keysym.sym)
+    case INPUT_EVENT_TYPE_HOTPLUG:
+      switch (event.hotplug_event.extension)
       {
-      case SDLK_0:
-        togglekey0 = 0;
+      case Nunchuk:
+      case Classic:
+      case BalanceBoard:
+        ir_object_clear(state, 0);
+        ir_object_clear(state, 1);
+        ir_object_clear(state, 2);
+        ir_object_clear(state, 3);
         break;
-      case SDLK_9:
-        togglekey9 = 0;
-        break;
-      case SDLK_LSHIFT:
-        shift = 0;
-        break;
-      case SDLK_a:
-        state->usr.a = 0;
-        state->usr.classic.a = 0;
-        break;
-      case SDLK_d:
-        state->usr.b = 0;
-        state->usr.classic.b = 0;
-        break;
-      case SDLK_q:
-        state->usr.nunchuk.c = 0;
-        state->usr.classic.x = 0;
-        break;
-      case SDLK_e:
-        state->usr.nunchuk.z = 0;
-        state->usr.classic.y = 0;
-        break;
-      case SDLK_1:
-        state->usr.one = 0;
-        break;
-      case SDLK_2:
-        state->usr.two = 0;
-        break;
-      case SDLK_3:
-        state->usr.minus = 0;
-        state->usr.classic.minus = 0;
-        break;
-      case SDLK_4:
-        state->usr.plus = 0;
-        state->usr.classic.plus = 0;
-        break;
-      case SDLK_h:
-        state->usr.home = 0;
-        break;
-      case SDLK_KP8:
-        state->usr.up = 0;
-        state->usr.classic.up = 0;
-        break;
-      case SDLK_KP2:
-        state->usr.down = 0;
-        state->usr.classic.down = 0;
-        break;
-      case SDLK_KP4:
-        state->usr.left = 0;
-        state->usr.classic.left = 0;
-        break;
-      case SDLK_KP6:
-        state->usr.right = 0;
-        state->usr.classic.right = 0;
-        break;
-  
-      case SDLK_UP:
-        up = 0;
-        break;
-      case SDLK_DOWN:
-        down = 0;
-        break;
-      case SDLK_LEFT:
-        left = 0;
-        break;
-      case SDLK_RIGHT:
-        right = 0;
-        break;
-
-      case SDLK_t:
-        steerleft = 0;
-        break;
-      case SDLK_y:
-        steerright = 0;
+      case NoExtension:
+        state->usr.ir_object[0].x = 400;
+        state->usr.ir_object[0].y = 400;
+        state->usr.ir_object[0].size = 8;
+        state->usr.ir_object[1].x = 600;
+        state->usr.ir_object[1].y = 400;
+        state->usr.ir_object[1].size = 8;
         break;
       default:
+        goto invalid;
+      }
+
+      state->usr.connected_extension_type = event.hotplug_event.extension;
+    invalid:
+      break;
+    case INPUT_EVENT_TYPE_BUTTON: {
+      bool pressed = event.button_event.pressed;
+      switch (event.button_event.button)
+      {
+      case INPUT_BUTTON_HOME:
+        state->usr.home = pressed;
+        break;
+
+      case INPUT_BUTTON_WIIMOTE_UP:
+        state->usr.up = pressed;
+        break;
+      case INPUT_BUTTON_WIIMOTE_DOWN:
+        state->usr.down = pressed;
+        break;
+      case INPUT_BUTTON_WIIMOTE_LEFT:
+        state->usr.left = pressed;
+        break;
+      case INPUT_BUTTON_WIIMOTE_RIGHT:
+        state->usr.right = pressed;
+        break;
+      case INPUT_BUTTON_WIIMOTE_A:
+        state->usr.a = pressed;
+        break;
+      case INPUT_BUTTON_WIIMOTE_B:
+        state->usr.b = pressed;
+        break;
+      case INPUT_BUTTON_WIIMOTE_1:
+        state->usr.one = pressed;
+        break;
+      case INPUT_BUTTON_WIIMOTE_2:
+        state->usr.two = pressed;
+        break;
+      case INPUT_BUTTON_WIIMOTE_PLUS:
+        state->usr.plus = pressed;
+        break;
+      case INPUT_BUTTON_WIIMOTE_MINUS:
+        state->usr.minus = pressed;
+        break;
+
+      case INPUT_BUTTON_NUNCHUK_C:
+        state->usr.nunchuk.c = pressed;
+        break;
+      case INPUT_BUTTON_NUNCHUK_Z:
+        state->usr.nunchuk.z = pressed;
+        break;
+
+      case INPUT_BUTTON_CLASSIC_UP:
+        state->usr.classic.up = pressed;
+        break;
+      case INPUT_BUTTON_CLASSIC_DOWN:
+        state->usr.classic.down = pressed;
+        break;
+      case INPUT_BUTTON_CLASSIC_LEFT:
+        state->usr.classic.left = pressed;
+        break;
+      case INPUT_BUTTON_CLASSIC_RIGHT:
+        state->usr.classic.right = pressed;
+        break;
+      case INPUT_BUTTON_CLASSIC_A:
+        state->usr.classic.a = pressed;
+      printf("classic A\n");
+        break;
+      case INPUT_BUTTON_CLASSIC_B:
+        state->usr.classic.b = pressed;
+      printf("classic B\n");
+        break;
+      case INPUT_BUTTON_CLASSIC_X:
+        state->usr.classic.x = pressed;
+      printf("classic X\n");
+        break;
+      case INPUT_BUTTON_CLASSIC_Y:
+        state->usr.classic.y = pressed;
+        break;
+      case INPUT_BUTTON_CLASSIC_L:
+        state->usr.classic.ltrigger = pressed;
+        break;
+      case INPUT_BUTTON_CLASSIC_R:
+        state->usr.classic.rtrigger = pressed;
+        break;
+      case INPUT_BUTTON_CLASSIC_ZL:
+        state->usr.classic.lz = pressed;
+      printf("classic ZL\n");
+        break;
+      case INPUT_BUTTON_CLASSIC_ZR:
+        state->usr.classic.rz = pressed;
+      printf("classic ZR\n");
+        break;
+      case INPUT_BUTTON_CLASSIC_PLUS:
+        state->usr.classic.plus = pressed;
+        break;
+      case INPUT_BUTTON_CLASSIC_MINUS:
+        state->usr.classic.minus = pressed;
+        break;
+      default:
+        printf("warning: button %d not handled by input_update\n", event.button_event.button);
         break;
       }
     }
+    case INPUT_EVENT_TYPE_ANALOG_MOTION: {
+      bool moving = event.analog_motion_event.moving;
+      switch (event.analog_motion_event.motion)
+      {
+        case INPUT_ANALOG_MOTION_IR_UP:
+          ir_up = moving;
+          break;
+        case INPUT_ANALOG_MOTION_IR_DOWN:
+          ir_down = moving;
+          break;
+        case INPUT_ANALOG_MOTION_IR_LEFT:
+          ir_left = moving;
+          break;
+        case INPUT_ANALOG_MOTION_IR_RIGHT:
+          ir_right = moving;
+          break;
+
+        case INPUT_ANALOG_MOTION_STEER_LEFT:
+          steer_left = moving;
+          break;
+        case INPUT_ANALOG_MOTION_STEER_RIGHT:
+          steer_right = moving;
+          break;
+
+        case INPUT_ANALOG_MOTION_NUNCHUK_UP:
+          nunchuk_up = moving;
+          break;
+        case INPUT_ANALOG_MOTION_NUNCHUK_DOWN:
+          nunchuk_down = moving;
+          break;
+        case INPUT_ANALOG_MOTION_NUNCHUK_LEFT:
+          nunchuk_left = moving;
+          break;
+        case INPUT_ANALOG_MOTION_NUNCHUK_RIGHT:
+          nunchuk_right = moving;
+          break;
+
+        case INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_UP:
+          classic_left_stick_up = moving;
+          break;
+        case INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_DOWN:
+          classic_left_stick_down = moving;
+          break;
+        case INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_LEFT:
+          classic_left_stick_left = moving;
+        printf("classic left %d\n", moving);
+          break;
+        case INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_RIGHT:
+          classic_left_stick_right = moving;
+        printf("classic right\n");
+          break;
+
+        case INPUT_ANALOG_MOTION_MOTIONPLUS_UP:
+          motionplus_up = moving;
+          break;
+        case INPUT_ANALOG_MOTION_MOTIONPLUS_DOWN:
+          motionplus_down = moving;
+          break;
+        case INPUT_ANALOG_MOTION_MOTIONPLUS_LEFT:
+          motionplus_left = moving;
+          break;
+        case INPUT_ANALOG_MOTION_MOTIONPLUS_RIGHT:
+          motionplus_right = moving;
+          break;
+        case INPUT_ANALOG_MOTION_MOTIONPLUS_SLOW:
+          motionplus_slow = moving;
+          break;
+      }
+    }
+    default:
+      break;
+    }
   }
 
-  if ((steerleft && steerright) || (!steerleft && !steerright))
+  if ((steer_left && steer_right) || (!steer_left && !steer_right))
   {
-    steerang = (PI / 2);
+    steer_angle = (PI / 2);
   }
-  else if (steerleft)
+  else if (steer_left)
   {
-    steerang = (6 * PI / 8);
+    steer_angle = (6 * PI / 8);
   }
-  else if (steerright)
+  else if (steer_right)
   {
-    steerang = (2 * PI / 8);
+    steer_angle = (2 * PI / 8);
   }
 
   /*
 
-       if (steerleft)
+       if (steer_left)
        {
-       if (steerang < (7 * PI / 8))
-       steerang += 0.02;
-       state->usr.accel_y = -cos(steerang) * (0x19 << 2) + 0x200;
-       state->usr.accel_x = -sin(steerang) * (0x19 << 2) + 0x200;
+       if (steer_angle < (7 * PI / 8))
+       steer_angle += 0.02;
+       state->usr.accel_y = -cos(steer_angle) * (0x19 << 2) + 0x200;
+       state->usr.accel_x = -sin(steer_angle) * (0x19 << 2) + 0x200;
        }
 
-       if (steerright)
+       if (steer_right)
        {
-       if (steerang > (1 * PI / 8))
-       steerang -= 0.02;
-       state->usr.accel_y = -cos(steerang) * (0x19 << 2) + 0x200;
-       state->usr.accel_x = -sin(steerang) * (0x19 << 2) + 0x200;
+       if (steer_angle > (1 * PI / 8))
+       steer_angle -= 0.02;
+       state->usr.accel_y = -cos(steer_angle) * (0x19 << 2) + 0x200;
+       state->usr.accel_x = -sin(steer_angle) * (0x19 << 2) + 0x200;
        }
 
 */
 
-  //state->usr.accel_y = -cos(steerang) * (0x19 << 2) + 0x200;
-  //state->usr.accel_x = -sin(steerang) * (0x19 << 2) + 0x200;
+  //state->usr.accel_y = -cos(steer_angle) * (0x19 << 2) + 0x200;
+  //state->usr.accel_x = -sin(steer_angle) * (0x19 << 2) + 0x200;
 
-  switch (arrow_function)
+  if (ir_down)
   {
-  case 0:
-    if (down)
+    if (state->usr.ir_object[0].y < 764)
     {
-      if (state->usr.ir_object[0].y < 764)
-      {
-        state->usr.ir_object[0].y += 4;
-        state->usr.ir_object[1].y += 4;
-      }
+      state->usr.ir_object[0].y += 4;
+      state->usr.ir_object[1].y += 4;
     }
-
-    if (up)
-    {
-      if (state->usr.ir_object[0].x > 3)
-      {
-        state->usr.ir_object[0].y -= 4;
-        state->usr.ir_object[1].y -= 4;
-      }
-    }
-
-    if (left)
-    {
-      if (state->usr.ir_object[0].x < 1020)
-      {
-        state->usr.ir_object[0].x += 4;
-        state->usr.ir_object[1].x += 4;
-      }
-    }
-
-    if (right)
-    {
-      if (state->usr.ir_object[0].x > 3)
-      {
-        state->usr.ir_object[0].x -= 4;
-        state->usr.ir_object[1].x -= 4;
-      }
-    }
-    break;
-  case 1:
-    state->usr.nunchuk.x = 128 + right * 100 - left * 100;
-    state->usr.nunchuk.y = 128 + up * 100 - down * 100;
-    break;
-  case 2:
-    state->usr.classic.ls_x = 32 + right * 30 - left * 30;
-    state->usr.classic.ls_y = 32 + up * 30 - down * 30;
-    break;
-  case 3:
-    state->usr.motionplus.pitch_left = 0x1F7F + down * 800 * (1 + shift) - up * 800 * (1 + shift);
-    state->usr.motionplus.yaw_down = 0x1F7F + left * 800 * (1 + shift) - right * 800 * (1 + shift);
-    state->usr.motionplus.pitch_slow = !shift;
-    state->usr.motionplus.yaw_slow = !shift;
-    break;
   }
+  if (ir_up)
+  {
+    if (state->usr.ir_object[0].x > 3)
+    {
+      state->usr.ir_object[0].y -= 4;
+      state->usr.ir_object[1].y -= 4;
+    }
+  }
+  if (ir_left)
+  {
+    if (state->usr.ir_object[0].x < 1020)
+    {
+      state->usr.ir_object[0].x += 4;
+      state->usr.ir_object[1].x += 4;
+    }
+  }
+  if (ir_right)
+  {
+    if (state->usr.ir_object[0].x > 3)
+    {
+      state->usr.ir_object[0].x -= 4;
+      state->usr.ir_object[1].x -= 4;
+    }
+  }
+
+  state->usr.nunchuk.x = 128 + nunchuk_right * 100 - nunchuk_left * 100;
+  state->usr.nunchuk.y = 128 + nunchuk_up * 100 - nunchuk_down * 100;
+
+  state->usr.classic.ls_x = 32 + classic_left_stick_right * 30 - classic_left_stick_left * 30;
+  state->usr.classic.ls_y = 32 + classic_left_stick_up * 30 - classic_left_stick_down * 30;
+
+  state->usr.motionplus.pitch_left = 0x1F7F + motionplus_down * 800 * (1 + !motionplus_slow) - motionplus_up * 800 * (1 + !motionplus_slow);
+  state->usr.motionplus.yaw_down = 0x1F7F + motionplus_left * 800 * (1 + !motionplus_slow) - motionplus_right * 800 * (1 + !motionplus_slow);
+  state->usr.motionplus.pitch_slow = motionplus_slow;
+  state->usr.motionplus.yaw_slow = motionplus_slow;
 
   return 0;
 }

--- a/input.h
+++ b/input.h
@@ -6,8 +6,122 @@
 
 #define PI 3.141592654
 
-void input_init();
-void input_unload();
-int input_update(struct wiimote_state * state);
+enum input_event_type
+{
+    INPUT_EVENT_TYPE_EMULATOR_CONTROL,
+    INPUT_EVENT_TYPE_HOTPLUG,
+    INPUT_EVENT_TYPE_BUTTON,
+    INPUT_EVENT_TYPE_ANALOG_MOTION,
+};
+
+enum input_emulator_control
+{
+    INPUT_EMULATOR_CONTROL_QUIT, // Quits the emulator
+    INPUT_EMULATOR_CONTROL_POWER_OFF, // Powers off host
+
+    INPUT_EMULATOR_CONTROL_TOGGLE_REPORTS,
+};
+
+struct input_emulator_control_event
+{
+    enum input_emulator_control control;
+};
+
+struct input_hotplug_event
+{
+    enum wiimote_connected_extension_type extension;
+};
+
+enum input_button
+{
+    INPUT_BUTTON_HOME,
+
+    INPUT_BUTTON_WIIMOTE_UP,
+    INPUT_BUTTON_WIIMOTE_DOWN,
+    INPUT_BUTTON_WIIMOTE_LEFT,
+    INPUT_BUTTON_WIIMOTE_RIGHT,
+    INPUT_BUTTON_WIIMOTE_A,
+    INPUT_BUTTON_WIIMOTE_B,
+    INPUT_BUTTON_WIIMOTE_1,
+    INPUT_BUTTON_WIIMOTE_2,
+    INPUT_BUTTON_WIIMOTE_PLUS,
+    INPUT_BUTTON_WIIMOTE_MINUS,
+
+    INPUT_BUTTON_NUNCHUK_C,
+    INPUT_BUTTON_NUNCHUK_Z,
+
+    INPUT_BUTTON_CLASSIC_UP,
+    INPUT_BUTTON_CLASSIC_DOWN,
+    INPUT_BUTTON_CLASSIC_LEFT,
+    INPUT_BUTTON_CLASSIC_RIGHT,
+    INPUT_BUTTON_CLASSIC_A,
+    INPUT_BUTTON_CLASSIC_B,
+    INPUT_BUTTON_CLASSIC_X,
+    INPUT_BUTTON_CLASSIC_Y,
+    INPUT_BUTTON_CLASSIC_L,
+    INPUT_BUTTON_CLASSIC_R,
+    INPUT_BUTTON_CLASSIC_ZL,
+    INPUT_BUTTON_CLASSIC_ZR,
+    INPUT_BUTTON_CLASSIC_PLUS,
+    INPUT_BUTTON_CLASSIC_MINUS,
+};
+
+struct input_button_event
+{
+    bool pressed;
+    enum input_button button;
+};
+
+enum input_analog_motion
+{
+    INPUT_ANALOG_MOTION_IR_UP,
+    INPUT_ANALOG_MOTION_IR_DOWN,
+    INPUT_ANALOG_MOTION_IR_LEFT,
+    INPUT_ANALOG_MOTION_IR_RIGHT,
+
+    INPUT_ANALOG_MOTION_STEER_LEFT,
+    INPUT_ANALOG_MOTION_STEER_RIGHT,
+
+    INPUT_ANALOG_MOTION_NUNCHUK_UP,
+    INPUT_ANALOG_MOTION_NUNCHUK_DOWN,
+    INPUT_ANALOG_MOTION_NUNCHUK_LEFT,
+    INPUT_ANALOG_MOTION_NUNCHUK_RIGHT,
+
+    INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_UP,
+    INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_DOWN,
+    INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_LEFT,
+    INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_RIGHT,
+
+    INPUT_ANALOG_MOTION_MOTIONPLUS_UP,
+    INPUT_ANALOG_MOTION_MOTIONPLUS_DOWN,
+    INPUT_ANALOG_MOTION_MOTIONPLUS_LEFT,
+    INPUT_ANALOG_MOTION_MOTIONPLUS_RIGHT,
+    INPUT_ANALOG_MOTION_MOTIONPLUS_SLOW,
+};
+
+struct input_analog_motion_event
+{
+    bool moving;
+    enum input_analog_motion motion;
+};
+
+struct input_event
+{
+    enum input_event_type type;
+    union {
+        struct input_emulator_control_event emulator_control_event;
+        struct input_hotplug_event hotplug_event;
+        struct input_button_event button_event;
+        struct input_analog_motion_event analog_motion_event;
+    };
+};
+
+struct input_source
+{
+    void (*unload)(void);
+    bool (*poll_event)(struct input_event *event);
+};
+
+int input_update(struct wiimote_state * state, struct input_source const * source);
 
 #endif

--- a/input_sdl.c
+++ b/input_sdl.c
@@ -1,0 +1,352 @@
+#include "input_sdl.h"
+#include "SDL/SDL.h"
+
+void input_sdl_init(void)
+{
+  if (SDL_Init(0) < 0)
+  {
+    printf("Could not initialize SDL: %s\n", SDL_GetError());
+    exit(1);
+  }
+  SDL_SetVideoMode(128, 128, 0, 0);
+  printf("Commands overview\n"
+         "-----------------\n"
+         "                 __ arrows use keypad numbers!\n"
+         "     ........  L'\n"
+         "    |   .    |\\           ,.._\n"
+         "    |   8    | |        ,'    \\\\\n"
+         "    | -4 6-  | |        |   ^  |\\\n"
+         "    |   2    | |        | <-|->/ |q\n"
+         "    |   '    | |\\       `   v '  |\n"
+         "    |  /-\\   | |b|      |     | _/e\n"
+         "    |  |a|   |  \\|      |     //\n"
+         "    |  \\-/   |   |      |    |/\n"
+         "    |        |   |      |    |\n"
+         "    | 3 h 4  |   |       \\   /\n"
+         "    |        |   |        --'\n"
+         "    |        |   |        _...______________,...\n"
+         "    |   2    |   |      ,'                      `-\n"
+         "    |        |   |     /   ^      3 h 4       q   `.\n"
+         "    |   1    |  /      | <-|->             e    a  |\n"
+         "    |        |-/       \\   v                 d     /\n"
+         "    '`'''''''           \\                        ,'\n"
+         "     _     _             `-..-'------------`...-'\n"
+         "   ,'       `.\n"
+         "  ,' t     y '.     0: toggles arrow keys between\n"
+         "  V           V        IR/nunchuk/classic/motion plus\n"
+         "                    ESC: quit\n\n");
+}
+
+static void input_sdl_unload(void)
+{
+  SDL_Quit();
+}
+
+int up, down, left, right;
+bool steerright, steerleft;
+double steerang = (PI / 2);
+int arrow_function = 0;
+bool togglekey0 = 0;
+bool togglekey9 = 0;
+bool shift;
+
+static bool input_sdl_poll_event(struct input_event *out_event)
+{
+  SDL_Event event;
+  if (!SDL_PollEvent(&event))
+  {
+    return false;
+  }
+
+  switch (event.type)
+  {
+  case SDL_KEYDOWN:
+  case SDL_KEYUP:
+    out_event->type = INPUT_EVENT_TYPE_BUTTON;
+    out_event->button_event.pressed = (event.type == SDL_KEYDOWN);
+
+    switch (event.key.keysym.sym)
+    {
+    case SDLK_ESCAPE:
+      if (event.type != SDL_KEYDOWN)
+      {
+        return false;
+      }
+
+      out_event->type = INPUT_EVENT_TYPE_EMULATOR_CONTROL;
+      if (shift)
+      {
+        out_event->emulator_control_event.control = INPUT_EMULATOR_CONTROL_POWER_OFF;
+      }
+      else
+      {
+        out_event->emulator_control_event.control = INPUT_EMULATOR_CONTROL_QUIT;
+      }
+      break;
+    case SDLK_0:
+      if (event.type == SDL_KEYUP)
+      {
+        togglekey0 = 0;
+        return false;
+      }
+      else if (togglekey0 == 0)
+      {
+        togglekey0 = 1;
+        arrow_function = (arrow_function + 1) % 4;
+        printf("arrows (IR, nunchuk, classic, wmp): %d \n", arrow_function);
+
+        out_event->type = INPUT_EVENT_TYPE_HOTPLUG;
+        if (arrow_function == 1)
+        {
+          out_event->hotplug_event.extension = Nunchuk;
+        }
+        else if (arrow_function == 2)
+        {
+          out_event->hotplug_event.extension = Classic;
+        }
+        else if (arrow_function == 3)
+        {
+          out_event->hotplug_event.extension = Nunchuk;
+        }
+        else
+        {
+          out_event->hotplug_event.extension = NoExtension;
+        }
+      }
+      break;
+    case SDLK_9:
+      if (event.type == SDL_KEYUP)
+      {
+        togglekey9 = 0;
+        return false;
+      }
+      else if (togglekey9 == 0)
+      {
+        togglekey9 = 1;
+
+        out_event->type = INPUT_EVENT_TYPE_EMULATOR_CONTROL;
+        out_event->emulator_control_event.control = INPUT_EMULATOR_CONTROL_TOGGLE_REPORTS;
+      }
+      break;
+    case SDLK_LSHIFT:
+      shift = (event.type == SDL_KEYDOWN);
+
+      out_event->type = INPUT_EVENT_TYPE_ANALOG_MOTION;
+      out_event->analog_motion_event.moving = !shift;
+      out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_MOTIONPLUS_SLOW;
+      break;
+    case SDLK_a:
+      if (arrow_function == 2)
+      {
+        out_event->button_event.button = INPUT_BUTTON_CLASSIC_A;
+      }
+      else
+      {
+        out_event->button_event.button = INPUT_BUTTON_WIIMOTE_A;
+      }
+      break;
+    case SDLK_d:
+      if (arrow_function == 2)
+      {
+        out_event->button_event.button = INPUT_BUTTON_CLASSIC_B;
+      }
+      else
+      {
+        out_event->button_event.button = INPUT_BUTTON_WIIMOTE_B;
+      }
+      break;
+    case SDLK_q:
+      if (arrow_function == 2)
+      {
+        out_event->button_event.button = INPUT_BUTTON_CLASSIC_X;
+      }
+      else
+      {
+        out_event->button_event.button = INPUT_BUTTON_NUNCHUK_C;
+      }
+      break;
+    case SDLK_e:
+      if (arrow_function == 2)
+      {
+        out_event->button_event.button = INPUT_BUTTON_CLASSIC_Y;
+      }
+      else
+      {
+        out_event->button_event.button = INPUT_BUTTON_NUNCHUK_Z;
+      }
+      break;
+    case SDLK_1:
+      out_event->button_event.button = INPUT_BUTTON_WIIMOTE_1;
+      break;
+    case SDLK_2:
+      out_event->button_event.button = INPUT_BUTTON_WIIMOTE_2;
+      break;
+    case SDLK_3:
+      if (arrow_function == 2)
+      {
+        out_event->button_event.button = INPUT_BUTTON_CLASSIC_MINUS;
+      }
+      else
+      {
+        out_event->button_event.button = INPUT_BUTTON_WIIMOTE_MINUS;
+      }
+      break;
+    case SDLK_4:
+      if (arrow_function == 2)
+      {
+        out_event->button_event.button = INPUT_BUTTON_CLASSIC_PLUS;
+      }
+      else
+      {
+        out_event->button_event.button = INPUT_BUTTON_WIIMOTE_PLUS;
+      }
+      break;
+    case SDLK_h:
+      out_event->button_event.button = INPUT_BUTTON_HOME;
+      break;
+    case SDLK_KP8:
+      if (arrow_function == 2)
+      {
+        out_event->button_event.button = INPUT_BUTTON_CLASSIC_UP;
+      }
+      else
+      {
+        out_event->button_event.button = INPUT_BUTTON_WIIMOTE_UP;
+      }
+      break;
+    case SDLK_KP2:
+      if (arrow_function == 2)
+      {
+        out_event->button_event.button = INPUT_BUTTON_CLASSIC_DOWN;
+      }
+      else
+      {
+        out_event->button_event.button = INPUT_BUTTON_WIIMOTE_DOWN;
+      }
+      break;
+    case SDLK_KP4:
+      if (arrow_function == 2)
+      {
+        out_event->button_event.button = INPUT_BUTTON_CLASSIC_LEFT;
+      }
+      else
+      {
+        out_event->button_event.button = INPUT_BUTTON_WIIMOTE_LEFT;
+      }
+      break;
+    case SDLK_KP6:
+      if (arrow_function == 2)
+      {
+        out_event->button_event.button = INPUT_BUTTON_CLASSIC_RIGHT;
+      }
+      else
+      {
+        out_event->button_event.button = INPUT_BUTTON_WIIMOTE_RIGHT;
+      }
+      break;
+
+    case SDLK_UP:
+      out_event->type = INPUT_EVENT_TYPE_ANALOG_MOTION;
+      out_event->analog_motion_event.moving = (event.type == SDL_KEYDOWN);
+      if (arrow_function == 0)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_IR_UP;
+      }
+      else if (arrow_function == 1)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_NUNCHUK_UP;
+      }
+      else if (arrow_function == 2)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_UP;
+      }
+      else
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_MOTIONPLUS_UP;
+      }
+      break;
+    case SDLK_DOWN:
+      out_event->type = INPUT_EVENT_TYPE_ANALOG_MOTION;
+      out_event->analog_motion_event.moving = (event.type == SDL_KEYDOWN);
+      if (arrow_function == 0)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_IR_DOWN;
+      }
+      else if (arrow_function == 1)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_NUNCHUK_DOWN;
+      }
+      else if (arrow_function == 2)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_DOWN;
+      }
+      else
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_MOTIONPLUS_DOWN;
+      }
+      break;
+    case SDLK_LEFT:
+      out_event->type = INPUT_EVENT_TYPE_ANALOG_MOTION;
+      out_event->analog_motion_event.moving = (event.type == SDL_KEYDOWN);
+      if (arrow_function == 0)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_IR_LEFT;
+      }
+      else if (arrow_function == 1)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_NUNCHUK_LEFT;
+      }
+      else if (arrow_function == 2)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_LEFT;
+      }
+      else
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_MOTIONPLUS_LEFT;
+      }
+      break;
+    case SDLK_RIGHT:
+      out_event->type = INPUT_EVENT_TYPE_ANALOG_MOTION;
+      out_event->analog_motion_event.moving = (event.type == SDL_KEYDOWN);
+      if (arrow_function == 0)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_IR_RIGHT;
+      }
+      else if (arrow_function == 1)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_NUNCHUK_RIGHT;
+      }
+      else if (arrow_function == 2)
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_CLASSIC_LEFT_STICK_RIGHT;
+      }
+      else
+      {
+        out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_MOTIONPLUS_RIGHT;
+      }
+      break;
+
+    case SDLK_t:
+      out_event->type = INPUT_EVENT_TYPE_ANALOG_MOTION;
+      out_event->analog_motion_event.moving = (event.type == SDL_KEYDOWN);
+      out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_STEER_LEFT;
+      break;
+    case SDLK_y:
+      out_event->type = INPUT_EVENT_TYPE_ANALOG_MOTION;
+      out_event->analog_motion_event.moving = (event.type == SDL_KEYDOWN);
+      out_event->analog_motion_event.motion = INPUT_ANALOG_MOTION_STEER_RIGHT;
+      break;
+
+    default:
+      return false;
+    }
+    return true;
+  default:
+    return false;
+  }
+}
+
+struct input_source input_source_sdl = {
+  .unload = input_sdl_unload,
+  .poll_event = input_sdl_poll_event
+};

--- a/input_sdl.h
+++ b/input_sdl.h
@@ -1,0 +1,11 @@
+#ifndef INPUT_SDL_H
+#define INPUT_SDL_H
+
+#include <stdbool.h>
+#include "input.h"
+
+void input_sdl_init(void);
+
+extern struct input_source input_source_sdl;
+
+#endif

--- a/input_socket.c
+++ b/input_socket.c
@@ -1,0 +1,255 @@
+#include "input_socket.h"
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netdb.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PROGRAM_NAME "wmemulator"
+
+static bool input_socket_init_from_addrinfo(struct addrinfo *addrinfo);
+
+static int sock;
+static char buf[512];
+static size_t buf_len;
+
+void input_socket_init_unix_at_path(char const *path)
+{
+  struct sockaddr_un address = {
+    .sun_family = AF_UNIX
+  };
+  strncpy(address.sun_path, path, sizeof address.sun_path);
+
+  unlink(path);
+  input_socket_init((struct sockaddr *)&address, sizeof address);
+}
+
+void input_socket_init_ip_on_port(char const *port)
+{
+  struct addrinfo hints = {
+    .ai_family = AF_UNSPEC,
+    .ai_socktype = SOCK_DGRAM,
+    .ai_flags = AI_PASSIVE
+  };
+  struct addrinfo *result_info;
+  int ret = getaddrinfo(NULL, port, &hints, &result_info);
+  if (ret)
+  {
+    printf(PROGRAM_NAME ": getaddrinfo: %s\n", gai_strerror(ret));
+    exit(1);
+  }
+
+  for (struct addrinfo *info = result_info; info; info = info->ai_next)
+  {
+    if (input_socket_init_from_addrinfo(info))
+    {
+      freeaddrinfo(result_info);
+      return;
+    }
+  }
+
+  printf(PROGRAM_NAME ": fatal: can't bind to port %s\n", port);
+  exit(1);
+}
+
+void input_socket_init(struct sockaddr *socket_address, socklen_t socket_address_size)
+{
+  sock = socket(socket_address->sa_family, SOCK_DGRAM | SOCK_NONBLOCK, 0);
+  if (sock == -1)
+  {
+    perror(PROGRAM_NAME);
+    exit(1);
+  }
+
+  if (bind(sock, socket_address, socket_address_size))
+  {
+    perror(PROGRAM_NAME);
+    exit(1);
+  }
+}
+
+static bool input_socket_init_from_addrinfo(struct addrinfo *addrinfo)
+{
+  sock = socket(addrinfo->ai_family, addrinfo->ai_socktype | SOCK_NONBLOCK, addrinfo->ai_protocol);
+  if (sock == -1)
+  {
+    return false;
+  }
+
+  if (bind(sock, addrinfo->ai_addr, addrinfo->ai_addrlen))
+  {
+    close(sock);
+    return false;
+  }
+
+  return true;
+}
+
+static void input_socket_unload(void)
+{
+  if (close(sock))
+  {
+    perror(PROGRAM_NAME);
+  }
+}
+
+static bool input_socket_poll_event(struct input_event *event)
+{
+  if (!buf_len)
+  {
+    buf_len = recv(sock, buf, sizeof(buf) - 1, 0);
+    if (buf_len == -1)
+    {
+      buf_len = 0;
+      if (!(errno == EAGAIN || errno == EWOULDBLOCK))
+      {
+        perror(PROGRAM_NAME);
+      }
+      return false;
+    }
+  }
+  buf[buf_len] = '\0';
+  printf("received %d bytes: %s\n", buf_len, buf);
+
+  event->type = INPUT_EVENT_TYPE_BUTTON;
+
+  char event_type_s[32], event_param_s[32];
+  int event_status;
+  if (sscanf(buf, "%32s %d %32s", event_type_s, &event_status, event_param_s) == EOF)
+  {
+    printf(PROGRAM_NAME ": received input in invalid format\n");
+    buf_len = 0;
+    return false;
+  }
+
+  if (strcmp(event_type_s, "emulator_control") == 0)
+  {
+    event->type = INPUT_EVENT_TYPE_EMULATOR_CONTROL;
+
+    if (strcmp(event_param_s, "quit") == 0)
+    {
+      event->emulator_control_event.control = INPUT_EMULATOR_CONTROL_QUIT;
+    }
+    else if (strcmp(event_param_s, "power_off") == 0)
+    {
+      event->emulator_control_event.control = INPUT_EMULATOR_CONTROL_POWER_OFF;
+    }
+  }
+  else if (strcmp(event_type_s, "hotplug") == 0)
+  {
+    event->type = INPUT_EVENT_TYPE_HOTPLUG;
+
+    if (event_status == 0)
+    {
+      event->hotplug_event.extension = NoExtension;
+    }
+    else if (strcmp(event_param_s, "nunchuk") == 0)
+    {
+      event->hotplug_event.extension = Nunchuk;
+    }
+    else if (strcmp(event_param_s, "classic") == 0)
+    {
+      event->hotplug_event.extension = Classic;
+    }
+    else if (strcmp(event_param_s, "balance_board") == 0)
+    {
+      event->hotplug_event.extension = BalanceBoard;
+    }
+    else
+    {
+      event->hotplug_event.extension = NoExtension;
+    }
+  }
+  else if (strcmp(event_type_s, "button") == 0)
+  {
+    event->type = INPUT_EVENT_TYPE_BUTTON;
+    event->button_event.pressed = event_status;
+
+#define CHECK(Button) if (strcmp(event_param_s, #Button) == 0) event->button_event.button = INPUT_BUTTON_##Button
+    CHECK(HOME);
+    else CHECK(WIIMOTE_UP);
+    else CHECK(WIIMOTE_DOWN);
+    else CHECK(WIIMOTE_LEFT);
+    else CHECK(WIIMOTE_RIGHT);
+    else CHECK(WIIMOTE_A);
+    else CHECK(WIIMOTE_B);
+    else CHECK(WIIMOTE_1);
+    else CHECK(WIIMOTE_2);
+    else CHECK(WIIMOTE_PLUS);
+    else CHECK(WIIMOTE_MINUS);
+    else CHECK(NUNCHUK_C);
+    else CHECK(NUNCHUK_Z);
+    else CHECK(CLASSIC_UP);
+    else CHECK(CLASSIC_DOWN);
+    else CHECK(CLASSIC_LEFT);
+    else CHECK(CLASSIC_RIGHT);
+    else CHECK(CLASSIC_A);
+    else CHECK(CLASSIC_B);
+    else CHECK(CLASSIC_X);
+    else CHECK(CLASSIC_Y);
+    else CHECK(CLASSIC_L);
+    else CHECK(CLASSIC_R);
+    else CHECK(CLASSIC_ZL);
+    else CHECK(CLASSIC_ZR);
+    else CHECK(CLASSIC_PLUS);
+    else CHECK(CLASSIC_MINUS);
+#undef CHECK
+    else
+    {
+      printf(PROGRAM_NAME ": received invalid 'button' parameter: %s\n", event_param_s);
+      buf_len = 0;
+      return false;
+    }
+  }
+  else if (strcmp(event_type_s, "analog_motion") == 0)
+  {
+    event->type = INPUT_EVENT_TYPE_ANALOG_MOTION;
+    event->analog_motion_event.moving = event_status;
+
+#define CHECK(Motion) if (strcmp(event_param_s, #Motion) == 0) event->analog_motion_event.motion = INPUT_ANALOG_MOTION_##Motion
+    CHECK(IR_UP);
+    else CHECK(IR_DOWN);
+    else CHECK(IR_LEFT);
+    else CHECK(IR_RIGHT);
+    else CHECK(STEER_LEFT);
+    else CHECK(STEER_RIGHT);
+    else CHECK(NUNCHUK_UP);
+    else CHECK(NUNCHUK_DOWN);
+    else CHECK(NUNCHUK_LEFT);
+    else CHECK(NUNCHUK_RIGHT);
+    else CHECK(CLASSIC_LEFT_STICK_UP);
+    else CHECK(CLASSIC_LEFT_STICK_DOWN);
+    else CHECK(CLASSIC_LEFT_STICK_LEFT);
+    else CHECK(CLASSIC_LEFT_STICK_RIGHT);
+    else CHECK(MOTIONPLUS_UP);
+    else CHECK(MOTIONPLUS_DOWN);
+    else CHECK(MOTIONPLUS_LEFT);
+    else CHECK(MOTIONPLUS_RIGHT);
+    else CHECK(MOTIONPLUS_SLOW);
+#undef CHECK
+    else
+    {
+      printf(PROGRAM_NAME ": received invalid 'analog_motion' parameter: %s\n", event_param_s);
+      buf_len = 0;
+      return false;
+    }
+  }
+  else
+  {
+    printf(PROGRAM_NAME ": received invalid event type: %s\n", event_type_s);
+    buf_len = 0;
+    return false;
+  }
+
+  buf_len = 0;
+  return true;
+}
+
+struct input_source input_source_socket = {
+  .unload = input_socket_unload,
+  .poll_event = input_socket_poll_event
+};

--- a/input_socket.h
+++ b/input_socket.h
@@ -1,0 +1,15 @@
+#ifndef INPUT_SOCKET_H
+#define INPUT_SOCKET_H
+
+#include <stdbool.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include "input.h"
+
+void input_socket_init_unix_at_path(char const *path);
+void input_socket_init_ip_on_port(char const *port);
+void input_socket_init(struct sockaddr *socket_address, socklen_t socket_address_size);
+
+extern struct input_source input_source_socket;
+
+#endif

--- a/wmemulator.c
+++ b/wmemulator.c
@@ -246,6 +246,7 @@ int main(int argc, char *argv[])
     input_source = input_source_socket;
   }
   else if (argc > 3 && strcmp(argv[3], "ip") == 0)
+  {
     input_socket_init_ip_on_port(argv[3]);
     input_source = input_source_socket;
   }
@@ -480,3 +481,4 @@ int main(int argc, char *argv[])
 
   return 0;
 }
+

--- a/wmemulator.c
+++ b/wmemulator.c
@@ -207,12 +207,12 @@ void disconnect()
 
 void print_usage(char *argv0)
 {
-  printf("usage: %s [ <wii-bdaddr> [ gui | socket ( unix <path> | ip <port> ) ] ]\n", argv0);
+  printf("usage: %s [ <wii-bdaddr> [ gui | unix <path> | ip <port> ] ]\n", argv0);
 }
 
 int main(int argc, char *argv[])
 {
-  struct input_source input_source = input_source_sdl;
+  struct input_source input_source;
 
   struct pollfd pfd[6];
   unsigned char buf[256];
@@ -235,35 +235,24 @@ int main(int argc, char *argv[])
     str2ba(argv[1], &host_bdaddr);
     has_host = 1;
   }
-  if (argc > 2)
+  if (argc <= 2 || strcmp(argv[2], "gui") == 0)
   {
-    if (strcmp(argv[2], "gui") == 0)
-    {
-      input_source = input_source_sdl;
-    }
-    else if (strcmp(argv[2], "socket") == 0)
-    {
-      if (argc > 4 && strcmp(argv[3], "unix") == 0)
-      {
-        input_socket_init_unix_at_path(argv[4]);
-      }
-      else if (argc > 4 && strcmp(argv[3], "ip") == 0)
-      {
-        input_socket_init_ip_on_port(argv[4]);
-      }
-      else
-      {
-        print_usage(*argv);
-        return 1;
-      }
-
-      input_source = input_source_socket;
-    }
-    else
-    {
-      print_usage(*argv);
-      return 1;
-    }
+    input_sdl_init();
+    input_source = input_source_sdl;
+  }
+  else if (argc > 3 && strcmp(argv[2], "unix") == 0)
+  {
+    input_socket_init_unix_at_path(argv[3]);
+    input_source = input_source_socket;
+  }
+  else if (argc > 3 && strcmp(argv[3], "ip") == 0)
+    input_socket_init_ip_on_port(argv[3]);
+    input_source = input_source_socket;
+  }
+  else
+  {
+    print_usage(*argv);
+    return 1;
   }
 
   //set up unload signals

--- a/wmemulator.c
+++ b/wmemulator.c
@@ -17,6 +17,8 @@
 #include "sdp.h"
 #include "wiimote.h"
 #include "input.h"
+#include "input_sdl.h"
+#include "input_socket.h"
 #include "adapter.h"
 
 #define PSM_SDP 1
@@ -203,8 +205,15 @@ void disconnect()
   int_fd = 0;
 }
 
+void print_usage(char *argv0)
+{
+  printf("usage: %s [ <wii-bdaddr> [ gui | socket ( unix <path> | ip <port> ) ] ]\n", argv0);
+}
+
 int main(int argc, char *argv[])
 {
+  struct input_source input_source = input_source_sdl;
+
   struct pollfd pfd[6];
   unsigned char buf[256];
   ssize_t len;
@@ -219,12 +228,42 @@ int main(int argc, char *argv[])
   {
     if (bachk(argv[1]) < 0)
     {
-      printf("usage: %s <wii-bdaddr>\n", *argv);
+      print_usage(*argv);
       return 1;
     }
 
     str2ba(argv[1], &host_bdaddr);
     has_host = 1;
+  }
+  if (argc > 2)
+  {
+    if (strcmp(argv[2], "gui") == 0)
+    {
+      input_source = input_source_sdl;
+    }
+    else if (strcmp(argv[2], "socket") == 0)
+    {
+      if (argc > 4 && strcmp(argv[3], "unix") == 0)
+      {
+        input_socket_init_unix_at_path(argv[4]);
+      }
+      else if (argc > 4 && strcmp(argv[3], "ip") == 0)
+      {
+        input_socket_init_ip_on_port(argv[4]);
+      }
+      else
+      {
+        print_usage(*argv);
+        return 1;
+      }
+
+      input_source = input_source_socket;
+    }
+    else
+    {
+      print_usage(*argv);
+      return 1;
+    }
   }
 
   //set up unload signals
@@ -247,7 +286,6 @@ int main(int argc, char *argv[])
   }
 #endif
 
-  input_init();
   wiimote_init(&state);
 
   if (has_host)
@@ -385,7 +423,7 @@ int main(int argc, char *argv[])
       }
     }
 
-    input_result = input_update(&state);
+    input_result = input_update(&state, &input_source);
     if (input_result)
     {
        running = 0;
@@ -449,7 +487,7 @@ int main(int argc, char *argv[])
 #endif
 
   wiimote_destroy(&state);
-  input_unload();
+  input_source.unload();
 
   return 0;
 }


### PR DESCRIPTION
* Turn input.{h,c} into a generic input source interface
* Move SDL-based input into input_sdl.{h,c}
  * Please note: I haven't personally tested this interface, please ensure it works before merging
* Add socket-based input in input_socket.{h,c}
* Modify wmemulator.c to accept input source parameter (`gui`, `unix <path>` (Unix socket) or `ip <port>`)
  * Please also note: I haven't used the IP mode, but it was trivial to add and seemed like a good idea

Rationale: [ButtonBeamer](https://github.com/ThatsJustCheesy/ButtonBeamer) translates user keystrokes from a web page into WiimoteEmulator commands, and relays them over the Unix socket interface. The result is a Wii remote control app.

If you want to test ButtonBeamer as an example:
* Run `./wmemulator <wii-bdaddr> unix /tmp/wmemulator_input`
* Go to the ButtonBeamer directory
* `npm install`
* `export PORT=<some-port> OUTPUT_SOCKET_PATH=/tmp/wmemulator_input` (or put each on a separate line in a file named `.env`)
* `npm start`
* Navigate to `http://localhost:<some-port>`, click in the blue region at the top, and (for instance) use arrow keys to move the Classic Controller cursor. (The controls are presently hardcoded to an MKWii configuration.)