### PR TITLE
Allow specifying 'pair' on command line

### DIFF
--- a/wmemulator.c
+++ b/wmemulator.c
@@ -226,14 +226,20 @@ int main(int argc, char *argv[])
 
   if (argc > 1)
   {
-    if (bachk(argv[1]) < 0)
+    if (strcmp(argv[1], "pair") == 0)
     {
-      print_usage(*argv);
-      return 1;
+      // Act as if nothing given.
     }
-
-    str2ba(argv[1], &host_bdaddr);
-    has_host = 1;
+    else if (bachk(argv[1]) >= 0)
+    {
+      str2ba(argv[1], &host_bdaddr);
+      has_host = 1;
+    }
+    else
+    {
+        print_usage(*argv);
+        return 1;
+    }
   }
   if (argc <= 2 || strcmp(argv[2], "gui") == 0)
   {


### PR DESCRIPTION
Minor modification to the command line arguments: The way I wrote it, there was no way to tell the emulator to self-pair _and_ use a non-SDL input interface. With this change, the magic argument `pair` where the address normally goes will do that.

e.g., `wmemulator pair unix /tmp/wmemulator_input`